### PR TITLE
Add mongoid 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,19 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.2.0
+  - 2.2.2
 
 gemfile:
   - Gemfile
   - gemfiles/mongoid_4.Gemfile
   - gemfiles/mongoid_5.Gemfile
+  - gemfiles/mongoid_6.Gemfile
+
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/mongoid_6.Gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/mongoid_6.Gemfile
+    - rvm: 2.1.0
+      gemfile: gemfiles/mongoid_6.Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ matrix:
       gemfile: gemfiles/mongoid_6.Gemfile
     - rvm: 2.1.0
       gemfile: gemfiles/mongoid_6.Gemfile
+
+before_install:
+  - gem update bundler

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mongoid-tags [![Build Status](https://travis-ci.org/haihappen/mongoid-tags.svg?branch=master)](https://travis-ci.org/haihappen/mongoid-tags)
+# mongoid-tags [![Build Status](https://travis-ci.org/ream88/mongoid-tags.svg?branch=master)](https://travis-ci.org/ream88/mongoid-tags)
 
 Mongoid::Tags adds a simple tagging system to your Mongoid documents,
 and allows you to query them using a boolean search syntax.

--- a/gemfiles/mongoid_6.Gemfile
+++ b/gemfiles/mongoid_6.Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '../'
+
+gem 'mongoid', github: 'mongodb/mongoid', ref: '7c2ff52a0c5292b8e6bf3a9a29bbb19abae3dd5f'

--- a/mongoid-tags.gemspec
+++ b/mongoid-tags.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Mongoid::Tags::VERSION
   spec.authors       = "Mario Uher"
   spec.email         = "uher.mario@gmail.com"
-  spec.homepage      = "https://github.com/haihappen/mongoid-tags"
+  spec.homepage      = "https://github.com/ream88/mongoid-tags"
   spec.summary       = "Simple tagging system with boolean search."
   spec.description   = "Mongoid::Tags adds a simple tagging system to your Mongoid documents, and allows you to query them using a boolean search syntax."
   spec.license       = "MIT"

--- a/mongoid-tags.gemspec
+++ b/mongoid-tags.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport', '~> 4.0'
-  spec.add_dependency 'mongoid', '>= 4.0.0', '<= 6.0.0'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 6.0.0'
+  spec.add_dependency 'mongoid', '>= 4.0.0', '< 7.0.0'
   spec.add_dependency 'treetop', '~> 1.5'
 
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
This PR adds mongoid 6 support to mongoid-tags. It also updates out-of-date urls to the github and travis pages found in the README and gemspec.
